### PR TITLE
Relaxed route constraint to Staff.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 DiscourseAkismet::Engine.routes.draw do
-  resource :admin_mod_queue, path: "/", constraints: AdminConstraint.new, only: [:index] do
+  resource :admin_mod_queue, path: "/", constraints: StaffConstraint.new, only: [:index] do
     collection do
       get    "/"            => "admin_mod_queue#index"
       get    "index"        => "admin_mod_queue#index"


### PR DESCRIPTION
This is something we relaxed and hadn't yet pushed to https://github.com/verdi327/akismet.

Not sure if this is in any contention with your thoughts around what moderators should/shouldn't be able to do. But in our experience trying to keep the admin role thinned out it really helped to allow others to moderate spam.
