### PR TITLE
Plugin url for development setup fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Also make sure to enable the `akismet_enabled` site setting.
 Do the following
 ````
 cd plugins
-git clone https://github.com/verdi327/akismet.git
+git clone https://github.com/discourse/discourse-akismet.git
 ````
 
 Once Discourse starts up make sure you enter your `akismet_api_key` under site settings.


### PR DESCRIPTION
The dev setup "git clone" line was pointing to an old url.

I accidentally used this line (quick copy+paste) and couldn't figure out why my build failed ...

I replaced the old git clone url (line 50) with the proper repo line.
