### PR TITLE
Consolidated review queue support

### DIFF
--- a/app/controllers/discourse_akismet/admin_mod_queue_controller.rb
+++ b/app/controllers/discourse_akismet/admin_mod_queue_controller.rb
@@ -3,6 +3,7 @@ module DiscourseAkismet
     requires_plugin 'discourse-akismet'
 
     def index
+      Discourse.deprecate("DiscourseAkismet::AdminModQueueController#index has been deprecated, please use the Reviewable API instead")
       render_json_dump(
         posts: serialize_data(DiscourseAkismet.needs_review, PostSerializer, add_excerpt: true),
         enabled: SiteSetting.akismet_enabled?,
@@ -11,6 +12,7 @@ module DiscourseAkismet
     end
 
     def confirm_spam
+      Discourse.deprecate("DiscourseAkismet::AdminModQueueController#confirm_spam has been deprecated, please use the Reviewable API instead")
       post = Post.with_deleted.find(params[:post_id])
       DiscourseAkismet.move_to_state(post, 'confirmed_spam')
       log_confirmation(post, 'confirmed_spam')
@@ -18,6 +20,7 @@ module DiscourseAkismet
     end
 
     def allow
+      Discourse.deprecate("DiscourseAkismet::AdminModQueueController#allow has been deprecated, please use the Reviewable API instead")
       post = Post.with_deleted.find(params[:post_id])
 
       Jobs.enqueue(:update_akismet_status, post_id: post.id, status: 'ham')
@@ -34,6 +37,7 @@ module DiscourseAkismet
     end
 
     def dismiss
+      Discourse.deprecate("DiscourseAkismet::AdminModQueueController#dismiss has been deprecated, please use the Reviewable API instead")
       post = Post.with_deleted.find(params[:post_id])
 
       DiscourseAkismet.move_to_state(post, 'dismissed')
@@ -43,6 +47,7 @@ module DiscourseAkismet
     end
 
     def delete_user
+      Discourse.deprecate("DiscourseAkismet::AdminModQueueController#delete_user has been deprecated, please use the Reviewable API instead")
       post = Post.with_deleted.find(params[:post_id])
       user = post.user
       DiscourseAkismet.move_to_state(post, 'confirmed_spam')
@@ -72,8 +77,8 @@ module DiscourseAkismet
 
     def user_deletion_opts
       base = {
-        context:           I18n.t('akismet.delete_reason', performed_by: current_user.username),
-        delete_posts:      true,
+        context: I18n.t('akismet.delete_reason', performed_by: current_user.username),
+        delete_posts: true,
         delete_as_spammer: true
       }
 

--- a/jobs/collect_akismet_feedback.rb
+++ b/jobs/collect_akismet_feedback.rb
@@ -1,0 +1,25 @@
+module Jobs
+  class CollectAkismetFeedback < ::Jobs::Scheduled
+    every 15.minutes
+
+    def execute(args)
+      return unless SiteSetting.akismet_enabled?
+      return if SiteSetting.akismet_api_key.blank?
+      return unless defined?(Reviewable)
+
+      statuses = [Reviewable.statuses[:approved], Reviewable.statuses[:rejected]]
+      post_ids = PostCustomField.where(name: 'AKISMET_STATE', value: 'needs_review').pluck(:post_id)
+      reviews = ReviewableFlaggedPost.select(:target_id, :target_type, :status).includes(:target)
+        .where(target_id: post_ids, target_type: Post.name)
+        .where(status: statuses)
+
+      reviews.each do |review|
+        approved = review.status == Reviewable.statuses[:approved]
+        result = approved ? 'ham' : 'spam'
+
+        DiscourseAkismet.move_to_state(review.target, "confirmed_#{result}")
+        Jobs.enqueue(:update_akismet_status, post_id: review.target_id, status: result) if approved
+      end
+    end
+  end
+end

--- a/lib/discourse_akismet.rb
+++ b/lib/discourse_akismet.rb
@@ -96,7 +96,9 @@ module DiscourseAkismet
             )
           end
 
-          ReviewableFlaggedPost.needs_review!(target: post, topic: post.topic, created_by: spam_reporter)
+          if defined?(Reviewable)
+            ReviewableFlaggedPost.needs_review!(target: post, topic: post.topic, created_by: spam_reporter)
+          end
         else
           DiscourseAkismet.move_to_state(post, 'checked')
         end

--- a/plugin.rb
+++ b/plugin.rb
@@ -17,7 +17,7 @@ after_initialize do
   require_dependency File.expand_path('../jobs/check_for_spam_posts.rb', __FILE__)
   require_dependency File.expand_path('../jobs/check_akismet_post.rb', __FILE__)
   require_dependency File.expand_path('../jobs/update_akismet_status.rb', __FILE__)
-  require_dependency File.expand_path('../jobs/update_akismet_status.rb', __FILE__)
+  require_dependency File.expand_path('../jobs/collect_akismet_feedback.rb', __FILE__)
 
   # Store extra data for akismet
   on(:post_created) do |post, params|

--- a/spec/jobs/collect_akismet_feedback_spec.rb
+++ b/spec/jobs/collect_akismet_feedback_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe Jobs::CollectAkismetFeedback do
+  before do
+    SiteSetting.akismet_api_key = 'not_a_real_key'
+    SiteSetting.akismet_enabled = true
+  end
+
+  let(:spam_reporter) { Fabricate(:admin) }
+  let(:post) do
+    Fabricate(:post).tap { |p| DiscourseAkismet.move_to_state(p, 'needs_review') }
+  end
+
+  it 'Does not collect Akismet feedback when the review is pending, ignored, or deleted' do
+    ReviewableFlaggedPost.needs_review!(target: post, topic: post.topic, created_by: spam_reporter)
+
+    Jobs.expects(:enqueue).never
+    DiscourseAkismet.expects(:move_to_state).never
+
+    described_class.new.execute({})
+  end
+
+  it 'Changes post and enqueues a job to submit feedback to Akismet when reviewable is accepted' do
+    review = ReviewableFlaggedPost.needs_review!(target: post, topic: post.topic, created_by: spam_reporter)
+    review.perform(spam_reporter, :agree_and_keep)
+
+    Jobs.expects(:enqueue).with(:update_akismet_status, post_id: post.id, status: 'ham')
+    DiscourseAkismet.expects(:move_to_state).with(post, 'confirmed_ham')
+
+    described_class.new.execute({})
+  end
+
+  it 'Only changes post state to confirmed_spam but does not submit feedback to Akismet' do
+    review = ReviewableFlaggedPost.needs_review!(target: post, topic: post.topic, created_by: spam_reporter)
+    review.perform(spam_reporter, :disagree)
+
+    Jobs.expects(:enqueue).never
+    DiscourseAkismet.expects(:move_to_state).with(post, 'confirmed_spam')
+
+    described_class.new.execute({})
+  end
+end

--- a/spec/lib/discourse_akismet_spec.rb
+++ b/spec/lib/discourse_akismet_spec.rb
@@ -84,4 +84,23 @@ describe DiscourseAkismet do
     end
   end
 
+  describe '#check_for_spam' do
+    it 'Creates a new ReviewableFlaggedPost when spam is confirmed by Akismet' do
+      post = Fabricate(:post)
+      DiscourseAkismet.move_to_state(post, 'new')
+
+      stub_spam_confirmation
+
+      DiscourseAkismet.check_for_spam(post)
+      reviewable_flagged_post = ReviewableFlaggedPost.last
+
+      expect(reviewable_flagged_post.status).to eq Reviewable.statuses[:pending]
+      expect(reviewable_flagged_post.post).to eq post
+    end
+
+    def stub_spam_confirmation
+      mock_response = Struct.new(:status, :body, :headers)
+      Excon.expects(:post).returns(mock_response.new(200, 'true'))
+    end
+  end
 end

--- a/spec/lib/discourse_akismet_spec.rb
+++ b/spec/lib/discourse_akismet_spec.rb
@@ -99,8 +99,8 @@ describe DiscourseAkismet do
     end
 
     def stub_spam_confirmation
-      mock_response = Struct.new(:status, :body, :headers)
-      Excon.expects(:post).returns(mock_response.new(200, 'true'))
+      comment_check_url = "https://#{SiteSetting.akismet_api_key}.rest.akismet.com/1.1/comment-check"
+      stub_request(:post, comment_check_url).to_return(body: 'true')
     end
   end
 end


### PR DESCRIPTION
### What's new?

  - Akismet queue is now deprecated
  - A `ReviewableFlaggedPost` is created when Akismet determines that a post is spam. This will be reviewed in the consolidated queue.
  - We collect results in a job to avoid having to modify the reviewable class with Akismet logic. With these, we provide feedback to Akismet and update the post status.