### PR TITLE
FIX: Avoid breaking the build when the reviewable API is not present.

### DIFF
--- a/spec/lib/discourse_akismet_spec.rb
+++ b/spec/lib/discourse_akismet_spec.rb
@@ -84,7 +84,7 @@ describe DiscourseAkismet do
     end
   end
 
-  describe '#check_for_spam' do
+  describe '#check_for_spam', if: defined?(Reviewable) do
     it 'Creates a new ReviewableAkismetPost when spam is confirmed by Akismet' do
       post = Fabricate(:post)
       DiscourseAkismet.move_to_state(post, 'new')

--- a/spec/lib/tasks/reviewables_spec.rb
+++ b/spec/lib/tasks/reviewables_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-describe 'Reviewables rake tasks' do
-
+describe 'Reviewables rake tasks', if: defined?(Reviewable) do
   before do
     Rake::Task.clear
     Discourse::Application.load_tasks

--- a/spec/models/reviewable_akismet_post_spec.rb
+++ b/spec/models/reviewable_akismet_post_spec.rb
@@ -1,21 +1,21 @@
 require 'rails_helper'
 
-describe ReviewableAkismetPost do
+describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
   let(:guardian) { Guardian.new }
   let(:reviewable) { ReviewableAkismetPost.new }
 
   describe '#build_actions' do
-    (Reviewable.statuses.keys - [:pending]).each do |status|
-      it 'Does not return available actions when the reviewable is no longer pending' do
+    it 'Does not return available actions when the reviewable is no longer pending' do
+      available_actions = (Reviewable.statuses.keys - [:pending]).reduce([]) do |actions, status|
         reviewable.status = Reviewable.statuses[status]
         an_action_id = :confirm_spam
 
-        actions = reviewable_actions(guardian)
-
-        expect(actions.to_a).to be_empty
+        actions.concat reviewable_actions(guardian).to_a
       end
-    end
 
+      expect(available_actions).to be_empty
+    end
+    
     it 'Adds the confirm spam action' do
       actions = reviewable_actions(guardian)
 
@@ -60,7 +60,7 @@ describe ReviewableAkismetPost do
   describe 'Performing actions on reviewable' do
     let(:post) { Fabricate(:post) }
     let(:admin) { Fabricate(:admin) }
-    let(:reviewable) { described_class.needs_review!(target: post, created_by: admin) }
+    let(:reviewable) { ReviewableAkismetPost.needs_review!(target: post, created_by: admin) }
 
     shared_examples 'It logs actions in the staff actions logger' do
       it 'Creates a UserHistory that reflects the action taken' do


### PR DESCRIPTION
Some tests will fail since the `Reviewable` API hasn't landed on master yet