### PR TITLE
Feature: Calculate system user score

### DIFF
--- a/lib/discourse_akismet.rb
+++ b/lib/discourse_akismet.rb
@@ -96,9 +96,11 @@ module DiscourseAkismet
           end
 
           if defined?(ReviewableAkismetPost)
-            ReviewableAkismetPost.needs_review!(
+            reviewable = ReviewableAkismetPost.needs_review!(
               created_by: spam_reporter, target: post, topic: post.topic, reviewable_by_moderator: true
             )
+
+            reviewable.add_score(spam_reporter, PostActionType.types[:spam], created_at: reviewable.created_at)
           end
         else
           DiscourseAkismet.move_to_state(post, 'checked')

--- a/spec/lib/discourse_akismet_spec.rb
+++ b/spec/lib/discourse_akismet_spec.rb
@@ -99,6 +99,20 @@ describe DiscourseAkismet do
       expect(reviewable_akismet_post.reviewable_by_moderator).to eq true
     end
 
+    it 'Creates a new score for the new reviewable' do
+      post = Fabricate(:post)
+      DiscourseAkismet.move_to_state(post, 'new')
+
+      stub_spam_confirmation
+
+      DiscourseAkismet.check_for_spam(post)
+      reviewable_akismet_score = ReviewableScore.last
+
+      expect(reviewable_akismet_score.user).to eq Discourse.system_user
+      expect(reviewable_akismet_score.reviewable_score_type).to eq PostActionType.types[:spam]
+      expect(reviewable_akismet_score.take_action_bonus).to be_zero
+    end
+
     def stub_spam_confirmation
       stub_request(:post, /rest.akismet.com/).to_return(body: 'true')
     end

--- a/spec/models/reviewable_akismet_post_spec.rb
+++ b/spec/models/reviewable_akismet_post_spec.rb
@@ -15,7 +15,7 @@ describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
 
       expect(available_actions).to be_empty
     end
-    
+
     it 'Adds the confirm spam action' do
       actions = reviewable_actions(guardian)
 
@@ -76,11 +76,21 @@ describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
         expect(action.post_id).to eq post.id
         expect(action.topic_id).to eq post.topic_id
       end
+
+      it 'Returns necessary information to update reviewable creator user stats' do
+        result = reviewable.perform admin, action
+
+        update_flag_stats = result.update_flag_stats
+
+        expect(update_flag_stats[:status]).to eq flag_stat_status
+        expect(update_flag_stats[:user_ids]).to match_array [reviewable.created_by_id]
+      end
     end
 
     describe '#perform_confirm_spam' do
       let(:action) { :confirm_spam }
       let(:action_name) { 'confirmed_spam' }
+      let(:flag_stat_status) { :agreed }
 
       it_behaves_like 'It logs actions in the staff actions logger'
 
@@ -94,6 +104,7 @@ describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
     describe '#perform_not_spam' do
       let(:action) { :not_spam }
       let(:action_name) { 'confirmed_ham' }
+      let(:flag_stat_status) { :disagreed }
 
       it_behaves_like 'It logs actions in the staff actions logger'
 
@@ -135,6 +146,7 @@ describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
     describe '#perform_ignore' do
       let(:action) { :ignore }
       let(:action_name) { 'ignored' }
+      let(:flag_stat_status) { :ignored }
 
       it_behaves_like 'It logs actions in the staff actions logger'
 
@@ -148,6 +160,7 @@ describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
     describe '#perform_confirm_delete' do
       let(:action) { :confirm_delete }
       let(:action_name) { 'confirmed_spam_deleted' }
+      let(:flag_stat_status) { :agreed }
 
       it_behaves_like 'It logs actions in the staff actions logger'
 


### PR DESCRIPTION
When the system creates a new `ReviewableAkismetPost` we create a `ReviewableScore`
 
When an action is performed on the reviewable, a flag in the `UserStat` gets updated. If the sum of those flags is over 100, we truncate them.