### PR TITLE
FIX: Added some tests related to #24. Tested and fixed some corner cases

### DIFF
--- a/app/controllers/discourse_akismet/admin_mod_queue_controller.rb
+++ b/app/controllers/discourse_akismet/admin_mod_queue_controller.rb
@@ -13,7 +13,7 @@ module DiscourseAkismet
     end
 
     def confirm_spam
-      if defined?(ReviewableAkismetPost)
+      if should_use_reviewable_api?
         reviewable.perform(current_user, :confirm_spam)
       else
         DiscourseAkismet.move_to_state(post, 'confirmed_spam')
@@ -24,7 +24,7 @@ module DiscourseAkismet
     end
 
     def allow
-      if defined?(ReviewableAkismetPost)
+      if should_use_reviewable_api?
         reviewable.perform(current_user, :not_spam)
       else
         Jobs.enqueue(:update_akismet_status, post_id: post.id, status: 'ham')
@@ -40,7 +40,7 @@ module DiscourseAkismet
     end
 
     def dismiss
-      if defined?(ReviewableAkismetPost)
+      if should_use_reviewable_api?
         reviewable.perform(current_user, :ignore)
       else
         DiscourseAkismet.move_to_state(post, 'dismissed')
@@ -51,7 +51,7 @@ module DiscourseAkismet
     end
 
     def delete_user
-      if defined?(ReviewableAkismetPost)
+      if should_use_reviewable_api?
         reviewable.perform(current_user, :confirm_delete)
       else
         user = post.user
@@ -67,6 +67,10 @@ module DiscourseAkismet
     end
 
     private
+
+    def should_use_reviewable_api?
+      defined?(ReviewableAkismetPost) && reviewable
+    end
 
     def log_confirmation(post, custom_type)
       topic = post.topic || Topic.with_deleted.find(post.topic_id)

--- a/models/reviewable_akismet_post.rb
+++ b/models/reviewable_akismet_post.rb
@@ -45,14 +45,14 @@ class ReviewableAkismetPost < Reviewable
       UserDestroyer.new(performed_by).destroy(target.user, user_deletion_opts(performed_by))
     end
 
-    successful_transition :deleted, :agreed
+    successful_transition :deleted, :agreed, recalculate_score: false
   end
 
   private
 
-  def successful_transition(to_state, update_flag_status)
+  def successful_transition(to_state, update_flag_status, recalculate_score: true)
     create_result(:success, to_state)  do |result|
-      result.recalculate_score = true
+      result.recalculate_score = recalculate_score
       result.update_flag_stats = { status: update_flag_status, user_ids: [created_by_id] }
     end
   end

--- a/spec/requests/admin_mod_queue_controller_spec.rb
+++ b/spec/requests/admin_mod_queue_controller_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe DiscourseAkismet::AdminModQueueController do
   let(:admin) { Fabricate(:admin) }
-  let(:post) { Fabricate(:post) }
+  let(:a_post) { Fabricate(:post) }
 
   before do
     sign_in(admin)
     SiteSetting.akismet_enabled = true
-    PostCustomField.create!(post: post, name: "AKISMET_STATE", value: "needs_review")
+    PostCustomField.create!(post: a_post, name: "AKISMET_STATE", value: "needs_review")
   end
 
   it "should include a post with excerpt" do
@@ -16,5 +16,46 @@ RSpec.describe DiscourseAkismet::AdminModQueueController do
 
     data = JSON.parse(response.body)
     expect(data["posts"][0]).to include("excerpt")
+  end
+
+  describe 'Reviewing posts with the new Reviewable API', if: defined?(Reviewable) do
+    shared_examples 'It uses the new Reviewable API or fallbacks to the existing behaviour' do
+      it 'successfully calls allow' do
+        post('/admin/plugins/akismet/allow.json', params: { post_id: a_post.id })
+
+        expect(response.code).to eq('200')
+      end
+
+      it 'successfully calls confirm_spam' do
+        post('/admin/plugins/akismet/confirm_spam.json', params: { post_id: a_post.id })
+
+        expect(response.code).to eq('200')
+      end
+
+      it 'successfully calls dismiss' do
+        post('/admin/plugins/akismet/dismiss.json', params: { post_id: a_post.id })
+
+        expect(response.code).to eq('200')
+      end
+
+      it 'successfully calls delete_user' do
+        delete('/admin/plugins/akismet/delete_user.json', params: { post_id: a_post.id })
+
+        expect(response.code).to eq('200')
+      end
+    end
+
+    context 'When the API is defined and the Reviewable exists' do
+      before do
+        ReviewableAkismetPost.needs_review!(target: a_post, created_by: a_post.user)
+      end
+
+      it_behaves_like 'It uses the new Reviewable API or fallbacks to the existing behaviour'
+    end
+
+    context 'When the API is defined but we did not migrate our current data' do
+      it_behaves_like 'It uses the new Reviewable API or fallbacks to the existing behaviour'
+    end
+
   end
 end


### PR DESCRIPTION
This PR adds some missing tests for #24  and some additional bugfixes:

-  When the user gets deleted, the score cannot be recalculated.
- If the `Reviewable` API is present but the pending reviews weren't migrated, we fallback to the old behavior