### PR TITLE
Feature: Hide the old akismet review queue 

### DIFF
--- a/assets/javascripts/discourse/initializers/add-akismet-count.js.es6
+++ b/assets/javascripts/discourse/initializers/add-akismet-count.js.es6
@@ -1,32 +1,41 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 
+function attachAkismetReviewCount(api) {
+  api.addFlagProperty("currentUser.akismet_review_count");
+  api.decorateWidget("hamburger-menu:admin-links", dec => {
+    return dec.attach("link", {
+      route: "adminPlugins.akismet",
+      label: "akismet.title",
+      badgeCount: "akismet_review_count",
+      badgeClass: "flagged-posts"
+    });
+  });
+};
+
+function subscribeToReviewCount(messageBus, user) {
+  messageBus.subscribe("/akismet_counts", function(result) {
+    if (result) {
+      user.set("akismet_review_count", result.akismet_review_count || 0);
+    };
+  });
+};
+
 export default {
   name: "add-akismet-count",
   before: "register-discourse-location",
   after: "inject-objects",
 
   initialize(container) {
-    const user = container.lookup("current-user:main");
+    const site = container.lookup("site:main");
+    if (!site.get("reviewable_api_enabled")) {
+      const user = container.lookup("current-user:main");
+      if (user && user.get("staff")) {
+        
+        withPluginApi("0.4", attachAkismetReviewCount);
 
-    if (user && user.get("staff")) {
-      withPluginApi("0.4", api => {
-        api.addFlagProperty("currentUser.akismet_review_count");
-        api.decorateWidget("hamburger-menu:admin-links", dec => {
-          return dec.attach("link", {
-            route: "adminPlugins.akismet",
-            label: "akismet.title",
-            badgeCount: "akismet_review_count",
-            badgeClass: "flagged-posts"
-          });
-        });
-      });
-
-      const messageBus = container.lookup("message-bus:main");
-      messageBus.subscribe("/akismet_counts", function(result) {
-        if (result) {
-          user.set("akismet_review_count", result.akismet_review_count || 0);
-        }
-      });
-    }
+        const messageBus = container.lookup("message-bus:main");
+        subscribeToReviewCount(messageBus, user);
+      };
+    };
   }
 };


### PR DESCRIPTION
This PR aims to hide the old Akismet queue when the new `Reviewable` API is present.

### How?
- The site serializer was extended so we can see if the API is enabled and decide whether or not we'll initialize the Akismet review count in the hamburger menu.
- The engine gets loaded conditionally based on the `reviewable.rb` file existence.

