### PR TITLE
Fix UI and remove #target calls

### DIFF
--- a/app/controllers/discourse_akismet/admin_mod_queue_controller.rb
+++ b/app/controllers/discourse_akismet/admin_mod_queue_controller.rb
@@ -77,8 +77,7 @@ module DiscourseAkismet
 
       StaffActionLogger.new(current_user).log_custom(custom_type,
         post_id: post.id,
-        topic_id: topic.id,
-        created_at: post.created_at,
+        topic_id: topic.id
       )
     end
 

--- a/assets/javascripts/discourse/templates/components/reviewable-akismet-post.hbs
+++ b/assets/javascripts/discourse/templates/components/reviewable-akismet-post.hbs
@@ -13,20 +13,15 @@
     </span>
   </div>
 
-  {{reviewable-topic-link topic=reviewable.topic}}
+  {{#if reviewable.topic}}
+    {{reviewable-topic-link topic=reviewable.topic}}
+  {{else}}
+    {{i18n "topic.deleted"}}
+  {{/if}}
 
   <div class='post-body'>
-    {{{ reviewable.cooked }}}
+    {{{ reviewable.payload.post_cooked }}}
   </div>
 
-  <table class='reviewable-scores'>
-    <tr>
-      <th class='user'>{{i18n "review.types.reviewable_flagged_post.flagged_by"}}</th>
-      <th>{{i18n "review.scores.description"}}</th>
-    </tr>
-    <tr class='reviewable-score'>
-        <td class='user'>{{i18n "akismet.reviewer"}}</td>
-        <td>{{i18n "akismet.reviewer_description"}}</td>
-    </tr>
-  </table>
+  {{yield}}
 </div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -31,9 +31,9 @@ en:
       not_enabled: "Akismet is not enabled right now."
       change_settings: "Change Settings"
 
-      reviewer: "Akismet"
-      reviewer_description: "Automatically flagged by system"
+    topic:
+      deleted: "[Topic Deleted]"
     review:
       types:
         reviewable_akismet_post:
-          title: "Spam Flagged Post"
+          title: "Akismet Flagged Post"

--- a/lib/discourse_akismet.rb
+++ b/lib/discourse_akismet.rb
@@ -90,14 +90,14 @@ module DiscourseAkismet
           # Send a message to the user explaining that it happened
           if SiteSetting.akismet_notify_user?
             SystemMessage.new(post.user).create(
-              'akismet_spam',
-              topic_title: post.topic.title
+              'akismet_spam', topic_title: post.topic.title
             )
           end
 
           if defined?(ReviewableAkismetPost)
             reviewable = ReviewableAkismetPost.needs_review!(
-              created_by: spam_reporter, target: post, topic: post.topic, reviewable_by_moderator: true
+              created_by: spam_reporter, target: post, topic: post.topic, reviewable_by_moderator: true,
+              payload: { post_cooked: post.cooked }
             )
 
             reviewable.add_score(spam_reporter, PostActionType.types[:spam], created_at: reviewable.created_at)

--- a/models/reviewable_akismet_post.rb
+++ b/models/reviewable_akismet_post.rb
@@ -24,10 +24,10 @@ class ReviewableAkismetPost < Reviewable
   end
 
   def perform_not_spam(performed_by, _args)
-    Jobs.enqueue(:update_akismet_status, post_id: target_id, status: 'ham')
+    Jobs.enqueue(:update_akismet_status, post_id: post.id, status: 'ham')
     log_confirmation(performed_by, 'confirmed_ham')
 
-    PostDestroyer.new(performed_by, target).recover if target.deleted_at
+    PostDestroyer.new(performed_by, post).recover if post.deleted_at
 
     successful_transition :rejected, :disagreed
   end
@@ -41,8 +41,8 @@ class ReviewableAkismetPost < Reviewable
   def perform_confirm_delete(performed_by, _args)
     log_confirmation(performed_by, 'confirmed_spam_deleted')
 
-    if Guardian.new(performed_by).can_delete_user?(target.user)
-      UserDestroyer.new(performed_by).destroy(target.user, user_deletion_opts(performed_by))
+    if Guardian.new(performed_by).can_delete_user?(post.user)
+      UserDestroyer.new(performed_by).destroy(post.user, user_deletion_opts(performed_by))
     end
 
     successful_transition :deleted, :agreed, recalculate_score: false
@@ -80,7 +80,7 @@ class ReviewableAkismetPost < Reviewable
     StaffActionLogger.new(performed_by).log_custom(custom_type,
       post_id: post.id,
       topic_id: post.topic_id,
-      created_at: target.created_at
+      created_at: post.created_at
     )
   end
 end

--- a/models/reviewable_akismet_post.rb
+++ b/models/reviewable_akismet_post.rb
@@ -79,8 +79,7 @@ class ReviewableAkismetPost < Reviewable
   def log_confirmation(performed_by, custom_type)
     StaffActionLogger.new(performed_by).log_custom(custom_type,
       post_id: post.id,
-      topic_id: post.topic_id,
-      created_at: post.created_at
+      topic_id: post.topic_id
     )
   end
 end

--- a/serializers/reviewable_akismet_post_serializer.rb
+++ b/serializers/reviewable_akismet_post_serializer.rb
@@ -1,5 +1,5 @@
 require_dependency 'reviewable_serializer'
 
 class ReviewableAkismetPostSerializer < ReviewableSerializer
-  target_attributes :cooked, :raw
+  payload_attributes :post_cooked
 end

--- a/spec/lib/discourse_akismet_spec.rb
+++ b/spec/lib/discourse_akismet_spec.rb
@@ -95,6 +95,7 @@ describe DiscourseAkismet do
       expect(reviewable_akismet_post.status).to eq Reviewable.statuses[:pending]
       expect(reviewable_akismet_post.post).to eq post
       expect(reviewable_akismet_post.reviewable_by_moderator).to eq true
+      expect(reviewable_akismet_post.payload['post_cooked']).to eq post.cooked
     end
 
     it 'Creates a new score for the new reviewable' do

--- a/spec/models/reviewable_akismet_post_spec.rb
+++ b/spec/models/reviewable_akismet_post_spec.rb
@@ -65,7 +65,6 @@ describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
 
     before do
       post.trash!(admin)
-      reviewable.reload
     end
 
     shared_examples 'It logs actions in the staff actions logger' do

--- a/spec/models/reviewable_akismet_post_spec.rb
+++ b/spec/models/reviewable_akismet_post_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
   let(:guardian) { Guardian.new }
-  let(:reviewable) { ReviewableAkismetPost.new }
 
   describe '#build_actions' do
+    let(:reviewable) { ReviewableAkismetPost.new }
+
     it 'Does not return available actions when the reviewable is no longer pending' do
       available_actions = (Reviewable.statuses.keys - [:pending]).reduce([]) do |actions, status|
         reviewable.status = Reviewable.statuses[status]
@@ -58,9 +59,14 @@ describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
   end
 
   describe 'Performing actions on reviewable' do
-    let(:post) { Fabricate(:post) }
     let(:admin) { Fabricate(:admin) }
-    let(:reviewable) { ReviewableAkismetPost.needs_review!(target: post, created_by: admin) }
+    let(:post) { Fabricate(:post) }
+    let(:reviewable) { ReviewableAkismetPost.needs_review!(target: post, created_by: admin).reload }
+
+    before do
+      post.trash!(admin)
+      reviewable.reload
+    end
 
     shared_examples 'It logs actions in the staff actions logger' do
       it 'Creates a UserHistory that reflects the action taken' do
@@ -123,17 +129,16 @@ describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
       end
 
       it 'Recovers the post' do
-        post.deleted_at = 3.minutes.ago
-        post.deleted_by = admin
-
         reviewable.perform admin, action
 
-        expect(post.deleted_at).to be_nil
-        expect(post.deleted_by).to be_nil
+        recovered_post = post.reload
+
+        expect(recovered_post.deleted_at).to be_nil
+        expect(recovered_post.deleted_by).to be_nil
       end
 
       it 'Does not try to recover the post if it was already recovered' do
-        post.deleted_at = nil
+        post.update(deleted_at: nil)
         event_triggered = false
 
         DiscourseEvent.on(:post_recovered) { event_triggered = true }
@@ -177,7 +182,7 @@ describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
       end
 
       it 'Does not delete the user when it cannot be deleted' do
-        post.user = admin
+        post.update(user: admin)
 
         reviewable.perform admin, action
 


### PR DESCRIPTION
### Changes

- Do not use #target because it could be nil when the post was deleted.
- Use standardized reviewable history and change title to show that it was reported by Akismet
- Fix a bug that was preventing Topic and Post serialization due to `deleted_at` scope