### PR TITLE
FEATURE: Register Akismet custom log types

### DIFF
--- a/app/controllers/discourse_akismet/admin_mod_queue_controller.rb
+++ b/app/controllers/discourse_akismet/admin_mod_queue_controller.rb
@@ -44,7 +44,7 @@ module DiscourseAkismet
         reviewable.perform(current_user, :ignore)
       else
         DiscourseAkismet.move_to_state(post, 'dismissed')
-        log_confirmation(post, 'dismissed')
+        log_confirmation(post, 'ignored')
       end
 
       render body: nil

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4,12 +4,12 @@ en:
       logs:
         staff_actions:
           actions:
-            confirmed_ham: "confirmed not spam"
-            confirmed_spam: "confirmed spam"
-            confirmed_spam_deleted: "confirmed spam and deleted user"
-            dismissed: 'dismissed spam'
-            ignore: 'ignore spam'
-
+            confirmed_ham: "Not spam"
+            confirmed_spam: "Confirm spam"
+            confirmed_spam_deleted: "Confirm spam and delete user"
+            dismissed: 'Dismiss spam'
+            ignored: 'Ignore spam'
+            
     akismet:
       title: "Akismet"
       confirm_spam: "Confirm Spam"
@@ -37,3 +37,4 @@ en:
       types:
         reviewable_akismet_post:
           title: "Akismet Flagged Post"
+

--- a/db/migrate/20190409153209_migrate_dismissed_custom_logs.rb
+++ b/db/migrate/20190409153209_migrate_dismissed_custom_logs.rb
@@ -1,17 +1,27 @@
 class MigrateDismissedCustomLogs < ActiveRecord::Migration[5.2]
   def up
     DB.exec <<~SQL
-      UPDATE user_histories
+      UPDATE user_histories AS uh
       SET custom_type = 'ignored'
-      WHERE custom_type = 'dismissed' AND action = #{UserHistory.actions[:custom_staff]}
+      FROM post_custom_fields AS pcf
+      WHERE 
+        uh.custom_type = 'dismissed' AND 
+        uh.action = #{UserHistory.actions[:custom_staff]} AND
+        uh.post_id = pcf.post_id AND
+        pcf.name = 'AKISMET_STATE' AND pcf.value = 'dismissed'
     SQL
   end
 
   def down
     DB.exec <<~SQL
-      UPDATE user_histories
+      UPDATE user_histories AS uh
       SET custom_type = 'dimissed'
-      WHERE custom_type = 'ignored' AND action = #{UserHistory.actions[:custom_staff]}
+      FROM post_custom_fields AS pcf
+      WHERE 
+        uh.custom_type = 'ignored' AND 
+        uh.action = #{UserHistory.actions[:custom_staff]} AND
+        uh.post_id = pcf.post_id AND
+        pcf.name = 'AKISMET_STATE' AND pcf.value = 'dismissed'
     SQL
   end
 end

--- a/db/migrate/20190409153209_migrate_dismissed_custom_logs.rb
+++ b/db/migrate/20190409153209_migrate_dismissed_custom_logs.rb
@@ -1,0 +1,17 @@
+class MigrateDismissedCustomLogs < ActiveRecord::Migration[5.2]
+  def up
+    DB.exec <<~SQL
+      UPDATE user_histories
+      SET custom_type = 'ignored'
+      WHERE custom_type = 'dismissed' AND action = #{UserHistory.actions[:custom_staff]}
+    SQL
+  end
+
+  def down
+    DB.exec <<~SQL
+      UPDATE user_histories
+      SET custom_type = 'dimissed'
+      WHERE custom_type = 'ignored' AND action = #{UserHistory.actions[:custom_staff]}
+    SQL
+  end
+end


### PR DESCRIPTION
- Avoid adding unnecessary methods to the serializers when the review queue is active.
- Extend staff actions with Akismet actions in UserHistory
- Migrate logs with 'dismissed' custom_type to 'ignored' since we should be consistent