### PR TITLE
FIX: Do not extend staff actions for older discourse versions

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -89,6 +89,8 @@ after_initialize do
     end
   end
 
-  staff_actions = %i[confirmed_spam confirmed_ham ignored confirmed_spam_deleted]
-  extend_list_method(UserHistory, :staff_actions, staff_actions)
+  if reviewable_api_enabled
+    staff_actions = %i[confirmed_spam confirmed_ham ignored confirmed_spam_deleted]
+    extend_list_method(UserHistory, :staff_actions, staff_actions)
+  end
 end


### PR DESCRIPTION
Do not extend staff actions if reviewable api is missing. This won't break the plugin for older discourse versions