### PR TITLE
FEATURE: Send user profiles to akismet

### DIFF
--- a/assets/javascripts/discourse/templates/components/reviewable-akismet-user.hbs
+++ b/assets/javascripts/discourse/templates/components/reviewable-akismet-user.hbs
@@ -1,0 +1,26 @@
+<div class='reviewable-user-info'>
+  <div class='reviewable-user-fields'>
+    <div class='reviewable-user-details username'>
+      <div class='name'>{{i18n "review.user.username"}}</div>
+      <div class='value'>
+        {{reviewable.payload.username}}
+      </div>
+    </div>
+    {{#if reviewable.payload.name}}
+      <div class='reviewable-user-details name'>
+        <div class='name'>{{i18n "review.user.name"}}</div>
+        <div class='value'>{{reviewable.payload.name}}</div>
+      </div>
+    {{/if}}
+    <div class='reviewable-user-details email'>
+      <div class='name'>{{i18n "review.user.email"}}</div>
+      <div class='value'>{{reviewable.payload.email}}</div>
+    </div>
+       <div class='reviewable-user-details bio'>
+      <div class='name'>{{i18n "review.user.bio"}}</div>
+      <div class='value'>{{reviewable.payload.bio}}</div>
+    </div>   
+  </div>
+  
+  {{yield}}
+</div>

--- a/assets/javascripts/discourse/templates/components/reviewable-akismet-user.hbs
+++ b/assets/javascripts/discourse/templates/components/reviewable-akismet-user.hbs
@@ -12,14 +12,18 @@
         <div class='value'>{{reviewable.payload.name}}</div>
       </div>
     {{/if}}
-    <div class='reviewable-user-details email'>
-      <div class='name'>{{i18n "review.user.email"}}</div>
-      <div class='value'>{{reviewable.payload.email}}</div>
-    </div>
-       <div class='reviewable-user-details bio'>
-      <div class='name'>{{i18n "review.user.bio"}}</div>
-      <div class='value'>{{reviewable.payload.bio}}</div>
-    </div>   
+    {{#if reviewable.payload.email}}
+      <div class='reviewable-user-details email'>
+        <div class='name'>{{i18n "review.user.email"}}</div>
+        <div class='value'>{{reviewable.payload.email}}</div>
+      </div>
+    {{/if}}
+    {{#if reviewable.payload.bio}}
+      <div class='reviewable-user-details bio'>
+        <div class='name'>{{i18n "review.user.bio"}}</div>
+        <div class='value'>{{reviewable.payload.bio}}</div>
+      </div>   
+    {{/if}}
   </div>
   
   {{yield}}

--- a/assets/javascripts/discourse/templates/components/reviewable-akismet-user.hbs
+++ b/assets/javascripts/discourse/templates/components/reviewable-akismet-user.hbs
@@ -6,24 +6,17 @@
         {{reviewable.payload.username}}
       </div>
     </div>
-    {{#if reviewable.payload.name}}
-      <div class='reviewable-user-details name'>
-        <div class='name'>{{i18n "review.user.name"}}</div>
-        <div class='value'>{{reviewable.payload.name}}</div>
-      </div>
-    {{/if}}
-    {{#if reviewable.payload.email}}
-      <div class='reviewable-user-details email'>
-        <div class='name'>{{i18n "review.user.email"}}</div>
-        <div class='value'>{{reviewable.payload.email}}</div>
-      </div>
-    {{/if}}
-    {{#if reviewable.payload.bio}}
-      <div class='reviewable-user-details bio'>
-        <div class='name'>{{i18n "review.user.bio"}}</div>
-        <div class='value'>{{reviewable.payload.bio}}</div>
-      </div>   
-    {{/if}}
+    {{reviewable-field classes='reviewable-user-details name'
+                               name=(i18n 'review.user.name')
+                               value=reviewable.payload.name}}
+    
+    {{reviewable-field classes='reviewable-user-details email'
+                       name=(i18n 'review.user.email')
+                       value=reviewable.payload.email}}
+
+    {{reviewable-field classes='reviewable-user-details bio'
+                       name=(i18n 'review.user.bio')
+                       value=reviewable.payload.bio}}
   </div>
   
   {{yield}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -15,6 +15,7 @@ en:
       confirm_spam: "Confirm Spam"
       not_spam: "Not Spam"
       confirm_delete: "Confirm Spam & Delete User"
+      reject_user_delete: "Delete User"
       refresh: "Refresh Posts"
       posts_to_review: "Posts to Review"
       dismiss: "Dismiss"
@@ -35,4 +36,6 @@ en:
       types:
         reviewable_akismet_post:
           title: "Akismet Flagged Post"
+        reviewable_akismet_user:
+          title: "Akismet Flagged User"
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -33,6 +33,8 @@ en:
       change_settings: "Change Settings"
 
     review:
+      user:
+        bio: "Bio"
       types:
         reviewable_akismet_post:
           title: "Akismet Flagged Post"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,6 +6,7 @@ en:
     skip_akismet_trust_level: "Don't submit posts to Akismet if the user is this trust level or higher."
     skip_akismet_posts: "Don't submit posts to Akismet if a user has posted this many times."
     akismet_notify_user: "Notify the user when Akismet has temporarily hidden a post."
+    akismet_review_users: "Send TL0 user bios to Akismet for spam checking."
 
   akismet:
     delete_reason: "determined by %{performed_by} to be a spammer"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,4 +14,6 @@ plugins:
     default: true
   skip_akismet_posts:
     default: 50
+  akismet_review_users:
+    default: false
 

--- a/jobs/regular/check_users_for_spam.rb
+++ b/jobs/regular/check_users_for_spam.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Jobs
+  class CheckUsersForSpam < Jobs::Base
+    def execute(args)
+      user = User.includes(:user_profile).find_by(id: args[:user_id])
+      raise Discourse::InvalidParameters.new(:user_id) unless user.present?
+
+      DiscourseAkismet.with_client do |client|
+        DiscourseAkismet::UsersBouncer.new.check_user(client, user)
+      end
+    end
+  end
+end

--- a/jobs/update_akismet_status.rb
+++ b/jobs/update_akismet_status.rb
@@ -4,19 +4,31 @@ module Jobs
   class UpdateAkismetStatus < Jobs::Base
 
     def execute(args)
-      raise Discourse::InvalidParameters.new(:post_id) unless args[:post_id].present?
+      raise Discourse::InvalidParameters.new(:target_id) unless args[:target_id].present?
+      raise Discourse::InvalidParameters.new(:target_class) unless args[:target_class].present?
       raise Discourse::InvalidParameters.new(:status) unless args[:status].present?
 
       return unless SiteSetting.akismet_enabled?
 
-      post = Post.with_deleted.where(id: args[:post_id]).first
-      return unless post.present?
+      target = if args[:target_class] == 'Post'
+        args[:target_class].constantize.with_deleted.where(id: args[:target_id]).first
+      elsif args[:target_class] == 'User'
+        args[:target_class].constantize.where(id: args[:target_id]).first
+      end
+
+      return unless target
+
+      akismet_args = if args[:target_class] == 'Post'
+        DiscourseAkismet.args_for_post(target)
+      elsif args[:target_class] == 'User'
+        DiscourseAkismet.args_for_user(target)
+      end
 
       DiscourseAkismet.with_client do |client|
         if args[:status] == 'ham'
-          client.submit_ham(DiscourseAkismet.args_for_post(post))
+          client.submit_ham(akismet_args)
         elsif args[:status] == 'spam'
-          client.submit_spam(DiscourseAkismet.args_for_post(post))
+          client.submit_spam(akismet_args)
         end
       end
     end

--- a/lib/discourse_akismet.rb
+++ b/lib/discourse_akismet.rb
@@ -62,26 +62,6 @@ module DiscourseAkismet
     extra_args
   end
 
-  def self.args_for_user(user)
-    user_auth_token = user.user_auth_tokens.last
-
-    extra_args = {
-      content_type: 'signup',
-      permalink: "#{Discourse.base_url}/u/#{user.username_lower}",
-      comment_author: user.username,
-      comment_content: user.user_profile.bio_raw,
-      user_ip: user_auth_token.client_ip.to_s,
-      user_agent: user_auth_token.user_agent
-    }
-
-    # Sending the email to akismet is optional
-    if SiteSetting.akismet_transmit_email?
-      extra_args[:comment_author_email] = user.email
-    end
-
-    extra_args
-  end
-
   def self.to_check
     PostCustomField.where(name: 'AKISMET_STATE', value: 'new')
       .where('posts.id IS NOT NULL')

--- a/lib/discourse_akismet.rb
+++ b/lib/discourse_akismet.rb
@@ -62,6 +62,26 @@ module DiscourseAkismet
     extra_args
   end
 
+  def self.args_for_user(user)
+    user_auth_token = user.user_auth_tokens.last
+
+    extra_args = {
+      content_type: 'signup',
+      permalink: "#{Discourse.base_url}/u/#{user.username_lower}",
+      comment_author: user.username,
+      comment_content: user.user_profile.bio_raw,
+      user_ip: user_auth_token.client_ip.to_s,
+      user_agent: user_auth_token.user_agent
+    }
+
+    # Sending the email to akismet is optional
+    if SiteSetting.akismet_transmit_email?
+      extra_args[:comment_author_email] = user.email
+    end
+
+    extra_args
+  end
+
   def self.to_check
     PostCustomField.where(name: 'AKISMET_STATE', value: 'new')
       .where('posts.id IS NOT NULL')

--- a/lib/discourse_akismet/users_bouncer.rb
+++ b/lib/discourse_akismet/users_bouncer.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module DiscourseAkismet
+  class UsersBouncer
+    VALID_STATUSES = %w[spam ham]
+
+    def enqueue_for_check(user)
+      profile = user.user_profile
+      return if user.trust_level > TrustLevel[0] || profile.bio_raw.blank? || profile.bio_raw_previously_changed?
+
+      Jobs.enqueue(:check_users_for_spam, user_id: user.id)
+    end
+
+    def check_user(client, user)
+      if client.comment_check(args_for_user(user))
+        spam_reporter = Discourse.system_user
+
+        reviewable = ReviewableAkismetUser.needs_review!(
+          target: user, reviewable_by_moderator: true,
+          created_by: spam_reporter,
+          payload: { username: user.username, name: user.name, email: user.email, bio: user.user_profile.bio_raw }
+        )
+
+        reviewable.add_score(
+          spam_reporter, PostActionType.types[:spam],
+          created_at: reviewable.created_at
+        )
+      end
+    end
+
+    def submit_feedback(client, status, user)
+      raise Discourse::InvalidParameters.new(:status) unless VALID_STATUSES.include?(status)
+      args = args_for_user(user)
+
+      if args[:status] == 'ham'
+        client.submit_ham(args)
+      elsif args[:status] == 'spam'
+        client.submit_spam(args)
+      end
+    end
+
+    private
+
+    def args_for_user(user)
+      user_auth_token = user.user_auth_tokens.last
+
+      extra_args = {
+        content_type: 'signup',
+        permalink: "#{Discourse.base_url}/u/#{user.username_lower}",
+        comment_author: user.username,
+        comment_content: user.user_profile.bio_raw,
+        user_ip: user_auth_token.client_ip.to_s,
+        user_agent: user_auth_token.user_agent
+      }
+
+      # Sending the email to akismet is optional
+      if SiteSetting.akismet_transmit_email?
+        extra_args[:comment_author_email] = user.email
+      end
+
+      extra_args
+    end
+  end
+end

--- a/lib/discourse_akismet/users_bouncer.rb
+++ b/lib/discourse_akismet/users_bouncer.rb
@@ -5,6 +5,7 @@ module DiscourseAkismet
     VALID_STATUSES = %w[spam ham]
 
     def enqueue_for_check(user)
+      return unless SiteSetting.akismet_review_users
       profile = user.user_profile
       return if user.trust_level > TrustLevel[0] || profile.bio_raw.blank? || profile.bio_raw_previously_changed?
 

--- a/models/reviewable_akismet_user.rb
+++ b/models/reviewable_akismet_user.rb
@@ -2,48 +2,28 @@
 
 require_dependency 'reviewable'
 
-class ReviewableAkismetPost < Reviewable
+class ReviewableAkismetUser < Reviewable
   def build_actions(actions, guardian, _args)
     return [] unless pending?
 
-    build_action(actions, :confirm_spam, icon: 'check')
     build_action(actions, :not_spam, icon: 'thumbs-up')
-    build_action(actions, :ignore, icon: 'times')
-    build_action(actions, :confirm_delete, icon: 'trash-alt', confirm: true) if guardian.is_staff?
-  end
-
-  def post
-    @post ||= (target || Post.with_deleted.find_by(id: target_id))
+    build_action(actions, :reject_user_delete, icon: 'trash-alt', confirm: true) if guardian.is_staff?
   end
 
   # Reviewable#perform should be used instead of these action methods.
   # These are only part of the public API because #perform needs them to be public.
 
-  def perform_confirm_spam(performed_by, _args)
-    log_confirmation(performed_by, 'confirmed_spam')
-
-    successful_transition :approved, :agreed
-  end
-
   def perform_not_spam(performed_by, _args)
     Jobs.enqueue(:update_akismet_status, target_id: target_id, target_class: target_type, status: 'ham')
     log_confirmation(performed_by, 'confirmed_ham')
 
-    PostDestroyer.new(performed_by, post).recover if post.deleted_at
-
     successful_transition :rejected, :disagreed
   end
 
-  def perform_ignore(performed_by, _args)
-    log_confirmation(performed_by, 'ignored')
-
-    successful_transition :ignored, :ignored
-  end
-
-  def perform_confirm_delete(performed_by, _args)
-    if Guardian.new(performed_by).can_delete_user?(post.user)
+  def perform_reject_user_delete(performed_by, _args)
+    if target && Guardian.new(performed_by).can_delete_user?(target)
       log_confirmation(performed_by, 'confirmed_spam_deleted')
-      UserDestroyer.new(performed_by).destroy(post.user, user_deletion_opts(performed_by))
+      UserDestroyer.new(performed_by).destroy(target, user_deletion_opts(performed_by))
     end
 
     successful_transition :deleted, :agreed, recalculate_score: false
@@ -78,9 +58,8 @@ class ReviewableAkismetPost < Reviewable
   end
 
   def log_confirmation(performed_by, custom_type)
-    StaffActionLogger.new(performed_by).log_custom(custom_type,
-      post_id: post.id,
-      topic_id: post.topic_id
-    )
+    StaffActionLogger.new(performed_by).log_custom(custom_type, {})
   end
+
+  def post; end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -9,6 +9,7 @@
 enabled_site_setting :akismet_enabled
 
 load File.expand_path('../lib/discourse_akismet.rb', __FILE__)
+load File.expand_path('../lib/discourse_akismet/users_bouncer.rb', __FILE__)
 load File.expand_path('../lib/akismet.rb', __FILE__)
 
 # Classes are not loaded at this point so we check for the file
@@ -29,6 +30,7 @@ end
 
 after_initialize do
   require_dependency File.expand_path('../jobs/check_for_spam_posts.rb', __FILE__)
+  require_dependency File.expand_path('../jobs/regular/check_users_for_spam.rb', __FILE__)
   require_dependency File.expand_path('../jobs/check_akismet_post.rb', __FILE__)
   require_dependency File.expand_path('../jobs/update_akismet_status.rb', __FILE__)
 
@@ -39,8 +41,17 @@ after_initialize do
     require_dependency File.expand_path('../models/reviewable_akismet_post.rb', __FILE__)
     require_dependency File.expand_path('../models/reviewable_akismet_user.rb', __FILE__)
     require_dependency File.expand_path('../serializers/reviewable_akismet_post_serializer.rb', __FILE__)
+    require_dependency File.expand_path('../serializers/reviewable_akismet_user_serializer.rb', __FILE__)
     register_reviewable_type ReviewableAkismetPost
     register_reviewable_type ReviewableAkismetUser
+
+    add_model_callback(UserProfile, :after_commit, on: :create) do
+      DiscourseAkismet::UsersBouncer.new.enqueue_for_check(user)
+    end
+
+    add_model_callback(UserProfile, :after_commit, on: :update) do
+      DiscourseAkismet::UsersBouncer.new.enqueue_for_check(user)
+    end
   else
     add_to_class(:guardian, :can_review_akismet?) do
       user.try(:staff?)

--- a/plugin.rb
+++ b/plugin.rb
@@ -37,8 +37,10 @@ after_initialize do
 
   if reviewable_api_enabled
     require_dependency File.expand_path('../models/reviewable_akismet_post.rb', __FILE__)
+    require_dependency File.expand_path('../models/reviewable_akismet_user.rb', __FILE__)
     require_dependency File.expand_path('../serializers/reviewable_akismet_post_serializer.rb', __FILE__)
     register_reviewable_type ReviewableAkismetPost
+    register_reviewable_type ReviewableAkismetUser
   else
     add_to_class(:guardian, :can_review_akismet?) do
       user.try(:staff?)

--- a/serializers/reviewable_akismet_user_serializer.rb
+++ b/serializers/reviewable_akismet_user_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_dependency 'reviewable_serializer'
+
+class ReviewableAkismetUserSerializer < ReviewableSerializer
+  payload_attributes :username, :name, :email, :bio
+end

--- a/spec/jobs/regular/check_users_for_spam_spec.rb
+++ b/spec/jobs/regular/check_users_for_spam_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Jobs::CheckUsersForSpam do
+  describe '#execute' do
+    it "should raise the right error when user_id is invalid" do
+      expect do
+        described_class.new.execute({})
+      end.to raise_error(Discourse::InvalidParameters)
+    end
+  end
+end

--- a/spec/lib/users_bouncer_spec.rb
+++ b/spec/lib/users_bouncer_spec.rb
@@ -6,7 +6,11 @@ require 'rails_helper'
 
 RSpec.describe DiscourseAkismet::UsersBouncer do
   describe '#enqueue_for_check' do
-    let(:user) { Fabricate.build(:user, user_profile: Fabricate.build(:user_profile)) }
+    before { SiteSetting.akismet_review_users = true }
+
+    let(:user) do
+      Fabricate.build(:user, user_profile: Fabricate.build(:user_profile), trust_level: TrustLevel[0])
+    end
 
     it 'does not enqueue for check if user trust level is higher than 0' do
       user.trust_level = TrustLevel[1]
@@ -15,15 +19,20 @@ RSpec.describe DiscourseAkismet::UsersBouncer do
     end
 
     it 'enqueues the user when trust level is higher than zero and bio is present' do
-      user.trust_level = TrustLevel[0]
       user.user_profile.bio_raw = "Let's spam"
 
       queued_jobs_for_check(user, 1)
     end
 
     it 'does not enqueue for check if user bio is empty' do
-      user.trust_level = TrustLevel[0]
       user.user_profile.bio_raw = ''
+
+      queued_jobs_for_check(user, 0)
+    end
+
+    it 'xxxxxxx' do
+      SiteSetting.akismet_review_users = false
+      user.user_profile.bio_raw = "Let's spam"
 
       queued_jobs_for_check(user, 0)
     end

--- a/spec/lib/users_bouncer_spec.rb
+++ b/spec/lib/users_bouncer_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+# frozen_string_literal
+
+require 'rails_helper'
+
+RSpec.describe DiscourseAkismet::UsersBouncer do
+  describe '#enqueue_for_check' do
+    let(:user) { Fabricate.build(:user, user_profile: Fabricate.build(:user_profile)) }
+
+    it 'does not enqueue for check if user trust level is higher than 0' do
+      user.trust_level = TrustLevel[1]
+
+      queued_jobs_for_check(user, 0)
+    end
+
+    it 'enqueues the user when trust level is higher than zero and bio is present' do
+      user.trust_level = TrustLevel[0]
+      user.user_profile.bio_raw = "Let's spam"
+
+      queued_jobs_for_check(user, 1)
+    end
+
+    it 'does not enqueue for check if user bio is empty' do
+      user.trust_level = TrustLevel[0]
+      user.user_profile.bio_raw = ''
+
+      queued_jobs_for_check(user, 0)
+    end
+
+    def queued_jobs_for_check(to_check, expected_queued_jobs)
+      expect {
+        subject.enqueue_for_check(to_check)
+      }.to change(Jobs::CheckUsersForSpam.jobs, :size).by(expected_queued_jobs)
+    end
+  end
+
+  describe '#check_user', if: defined?(Reviewable) do
+    let(:user) do
+      Fabricate(:user, trust_level: TrustLevel[0])
+    end
+
+    before { UserAuthToken.generate!(user_id: user.id) }
+
+    it "does not create a reviewable if akismet says it's not spam" do
+      should_find_spam = false
+
+      subject.check_user(build_client(should_find_spam), user)
+
+      expect(ReviewableAkismetUser.count).to be_zero
+    end
+
+    it "creates a reviewable if akismet says it's spam" do
+      should_find_spam = true
+
+      subject.check_user(build_client(should_find_spam), user)
+      created_reviewable = ReviewableAkismetUser.last
+      created_score = ReviewableScore.last
+
+      assert_reviewable_was_created_correctly(created_reviewable)
+      assert_score_was_created(created_score)
+    end
+
+    def assert_reviewable_was_created_correctly(reviewable)
+      expect(reviewable.target).to eq user
+      expect(reviewable.created_by).to eq Discourse.system_user
+      expect(reviewable.reviewable_by_moderator).to eq true
+      expect(reviewable.payload['username']).to eq user.username
+      expect(reviewable.payload['name']).to eq user.name
+      expect(reviewable.payload['email']).to eq user.email
+      expect(reviewable.payload['bio']).to eq user.user_profile.bio_raw
+    end
+
+    def assert_score_was_created(score)
+      expect(score.user).to eq Discourse.system_user
+      expect(score.reviewable_score_type).to eq PostActionType.types[:spam]
+      expect(score.take_action_bonus).to be_zero
+    end
+
+    def build_client(detect_spam)
+      mock('Akismet::Client').tap do |client|
+        client.expects(:comment_check).returns(detect_spam)
+      end
+    end
+  end
+
+  describe '#submit_feedback' do
+    let(:user) { Fabricate(:user) }
+
+    it 'validates that the status is valid' do
+      non_valid_status = 'clear'
+      client = mock('Akismet::Client')
+
+      expect do
+        described_class.new.submit_feedback(client, non_valid_status, user)
+      end.to raise_error(Discourse::InvalidParameters)
+    end
+  end
+end

--- a/spec/models/reviewable_akismet_post_spec.rb
+++ b/spec/models/reviewable_akismet_post_spec.rb
@@ -122,11 +122,9 @@ describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
       end
 
       it 'Sends feedback to Akismet since post was not spam' do
-        Jobs.stubs(:enqueue).with(Not(equals(:update_akismet_status)), anything)
-
-        Jobs.expects(:enqueue).with(:update_akismet_status, post_id: post.id, status: 'ham')
-
-        reviewable.perform admin, action
+        expect {
+          reviewable.perform admin, action
+        }.to change(Jobs::UpdateAkismetStatus.jobs, :size).by(1)
       end
 
       it 'Recovers the post' do

--- a/spec/models/reviewable_akismet_user_spec.rb
+++ b/spec/models/reviewable_akismet_user_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'ReviewableAkismetUser', if: defined?(Reviewable) do
+  let(:guardian) { Guardian.new }
+
+  describe '#build_actions' do
+    let(:reviewable) { ReviewableAkismetUser.new }
+
+    it 'does not return available actions when the reviewable is no longer pending' do
+      available_actions = (Reviewable.statuses.keys - [:pending]).reduce([]) do |actions, status|
+        reviewable.status = Reviewable.statuses[status]
+        an_action_id = :not_spam
+
+        actions.concat reviewable_actions(guardian).to_a
+      end
+
+      expect(available_actions).to be_empty
+    end
+
+    it 'adds the not spam action' do
+      actions = reviewable_actions(guardian)
+
+      expect(actions.has?(:not_spam)).to be true
+    end
+
+    it 'adds the confirm delete action' do
+      admin = Fabricate(:admin)
+      guardian = Guardian.new(admin)
+
+      actions = reviewable_actions(guardian)
+
+      expect(actions.has?(:reject_user_delete)).to be true
+    end
+
+    it 'excludes the confirm delete action when the user is not an staff member' do
+      actions = reviewable_actions(guardian)
+
+      expect(actions.has?(:perform_reject_user_delete)).to be false
+    end
+
+    def reviewable_actions(guardian)
+      actions = Reviewable::Actions.new(reviewable, guardian, {})
+      reviewable.build_actions(actions, guardian, {})
+
+      actions
+    end
+  end
+
+  describe 'performing actions on reviewable' do
+    let(:admin) { Fabricate(:admin) }
+    let(:user) { Fabricate(:user) }
+    let(:reviewable) { ReviewableAkismetUser.needs_review!(target: user, created_by: admin) }
+
+    shared_examples 'it logs actions in the staff actions logger' do
+      it 'creates a UserHistory that reflects the action taken' do
+        reviewable.perform admin, action
+
+        admin_last_action = UserHistory.find_by!(acting_user_id: admin)
+
+        assert_history_reflects_action(admin_last_action, admin, action_name)
+      end
+
+      def assert_history_reflects_action(action, admin, action_name)
+        expect(action.custom_type).to eq action_name
+        expect(action.acting_user).to eq admin
+      end
+
+      it 'returns necessary information to update reviewable creator user stats' do
+        result = reviewable.perform admin, action
+
+        update_flag_stats = result.update_flag_stats
+
+        expect(update_flag_stats[:status]).to eq flag_stat_status
+        expect(update_flag_stats[:user_ids]).to match_array [reviewable.created_by_id]
+      end
+    end
+
+    describe '#perform_not_spam' do
+      let(:action) { :not_spam }
+      let(:action_name) { 'confirmed_ham' }
+      let(:flag_stat_status) { :disagreed }
+
+      it_behaves_like 'it logs actions in the staff actions logger'
+
+      it 'sets post as clear and reviewable status is changed to rejected' do
+        result = reviewable.perform admin, action
+
+        expect(result.transition_to).to eq :rejected
+      end
+
+      it 'sends feedback to Akismet since post was not spam' do
+        expect {
+          reviewable.perform admin, action
+        }.to change(Jobs::UpdateAkismetStatus.jobs, :size).by(1)
+      end
+    end
+
+    describe '#perform_reject_user_delete' do
+      let(:action) { :reject_user_delete }
+      let(:action_name) { 'confirmed_spam_deleted' }
+      let(:flag_stat_status) { :agreed }
+
+      it_behaves_like 'it logs actions in the staff actions logger'
+
+      it 'confirms spam and reviewable status is changed to deleted' do
+        result = reviewable.perform admin, action
+
+        expect(result.transition_to).to eq :deleted
+      end
+
+      it 'deletes the user' do
+        reviewable.perform admin, action
+
+        expect { user.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We'll send TL0 user profiles to Akismet every time a `UserProfile` gets created or updated.

I created a `UsersBouncer` object to encapsulate all this behavior and interact with `DiscourseAkismet::Client`. This way, we favor dependency injection and avoid leaking implementation details like which args we should send Akismet.

![Screen Shot 2019-05-20 at 15 14 44](https://user-images.githubusercontent.com/5025816/58042813-0aa93580-7b12-11e9-83fd-a72cd9b09cee.png)
