### PR TITLE
FIX: Submit feedback correctly

### DIFF
--- a/jobs/update_akismet_status.rb
+++ b/jobs/update_akismet_status.rb
@@ -2,48 +2,21 @@
 
 module Jobs
   class UpdateAkismetStatus < Jobs::Base
-
     def execute(args)
-      raise Discourse::InvalidParameters.new(:target_id) unless args[:target_id].present?
-      raise Discourse::InvalidParameters.new(:target_class) unless args[:target_class].present?
-      raise Discourse::InvalidParameters.new(:status) unless args[:status].present?
-
       return unless SiteSetting.akismet_enabled?
 
-      target = find_target(args[:target_class], args[:target_id])
-      return unless target
+      akismet_feedback = args[:feedback]
+      status = args[:status]
+      raise Discourse::InvalidParameters.new(:feedback) unless akismet_feedback
+      raise Discourse::InvalidParameters.new(:status) unless status
 
       DiscourseAkismet.with_client do |client|
-        if args[:target_class] == 'Post'
-          submit_post_feedback(client, args[:status], target)
-        elsif args[:target_class] == 'User'
-          submit_user_feedback(client, args[:status], target)
+        if status == 'ham'
+          client.submit_ham(akismet_feedback)
+        elsif status == 'spam'
+          client.submit_spam(akismet_feedback)
         end
       end
-    end
-
-    private
-
-    def find_target(klass_name, id)
-      if klass_name == 'Post'
-        klass_name.constantize.with_deleted.find_by(id: id)
-      elsif klass_name == 'User'
-        klass_name.constantize.find_by(id: id)
-      end
-    end
-
-    def submit_post_feedback(client, status, post)
-      args = DiscourseAkismet.args_for_post(post)
-
-      if args[:status] == 'ham'
-        client.submit_ham(args)
-      elsif args[:status] == 'spam'
-        client.submit_spam(args)
-      end
-    end
-
-    def submit_user_feedback(client, status, user)
-      DiscourseAkismet::UsersBouncer.new.submit_feedback(client, status, user)
     end
   end
 end

--- a/lib/discourse_akismet.rb
+++ b/lib/discourse_akismet.rb
@@ -42,6 +42,12 @@ module DiscourseAkismet
     end
   end
 
+  def self.submit_feedback(post, status)
+    feedback = args_for_post(post)
+
+    Jobs.enqueue(:update_akismet_status, feedback: feedback, status: status)
+  end
+
   def self.args_for_post(post)
     extra_args = {
       content_type: 'forum-post',

--- a/lib/discourse_akismet/users_bouncer.rb
+++ b/lib/discourse_akismet/users_bouncer.rb
@@ -30,15 +30,11 @@ module DiscourseAkismet
       end
     end
 
-    def submit_feedback(client, status, user)
+    def submit_feedback(user, status)
       raise Discourse::InvalidParameters.new(:status) unless VALID_STATUSES.include?(status)
-      args = args_for_user(user)
+      feedback = args_for_user(user)
 
-      if args[:status] == 'ham'
-        client.submit_ham(args)
-      elsif args[:status] == 'spam'
-        client.submit_spam(args)
-      end
+      Jobs.enqueue(:update_akismet_status, feedback: feedback, status: status)
     end
 
     private

--- a/spec/lib/users_bouncer_spec.rb
+++ b/spec/lib/users_bouncer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe DiscourseAkismet::UsersBouncer do
       queued_jobs_for_check(user, 0)
     end
 
-    it 'xxxxxxx' do
+    it 'does not enqueue for check if the setting is turned off' do
       SiteSetting.akismet_review_users = false
       user.user_profile.bio_raw = "Let's spam"
 
@@ -94,14 +94,13 @@ RSpec.describe DiscourseAkismet::UsersBouncer do
   end
 
   describe '#submit_feedback' do
-    let(:user) { Fabricate(:user) }
+    let(:user) { Fabricate.build(:user) }
 
     it 'validates that the status is valid' do
       non_valid_status = 'clear'
-      client = mock('Akismet::Client')
 
       expect do
-        described_class.new.submit_feedback(client, non_valid_status, user)
+        described_class.new.submit_feedback(non_valid_status, user)
       end.to raise_error(Discourse::InvalidParameters)
     end
   end

--- a/spec/models/reviewable_akismet_post_spec.rb
+++ b/spec/models/reviewable_akismet_post_spec.rb
@@ -94,12 +94,21 @@ describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
       end
     end
 
+    shared_examples 'it submits feedback to Akismet' do
+      it 'queus a job tu submit feedback' do
+        expect {
+          reviewable.perform admin, action
+        }.to change(Jobs::UpdateAkismetStatus.jobs, :size).by(1)
+      end
+    end
+
     describe '#perform_confirm_spam' do
       let(:action) { :confirm_spam }
       let(:action_name) { 'confirmed_spam' }
       let(:flag_stat_status) { :agreed }
 
       it_behaves_like 'It logs actions in the staff actions logger'
+      it_behaves_like 'it submits feedback to Akismet'
 
       it 'Confirms spam and reviewable status is changed to approved' do
         result = reviewable.perform admin, action
@@ -114,6 +123,7 @@ describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
       let(:flag_stat_status) { :disagreed }
 
       it_behaves_like 'It logs actions in the staff actions logger'
+      it_behaves_like 'it submits feedback to Akismet'
 
       it 'Set post as clear and reviewable status is changed to rejected' do
         result = reviewable.perform admin, action
@@ -167,6 +177,7 @@ describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
       let(:flag_stat_status) { :agreed }
 
       it_behaves_like 'It logs actions in the staff actions logger'
+      it_behaves_like 'it submits feedback to Akismet'
 
       it 'Confirms spam and reviewable status is changed to deleted' do
         result = reviewable.perform admin, action

--- a/spec/models/reviewable_akismet_post_spec.rb
+++ b/spec/models/reviewable_akismet_post_spec.rb
@@ -95,7 +95,7 @@ describe 'ReviewableAkismetPost', if: defined?(Reviewable) do
     end
 
     shared_examples 'it submits feedback to Akismet' do
-      it 'queus a job tu submit feedback' do
+      it 'queues a job to submit feedback' do
         expect {
           reviewable.perform admin, action
         }.to change(Jobs::UpdateAkismetStatus.jobs, :size).by(1)

--- a/spec/models/reviewable_akismet_user_spec.rb
+++ b/spec/models/reviewable_akismet_user_spec.rb
@@ -80,7 +80,7 @@ describe 'ReviewableAkismetUser', if: defined?(Reviewable) do
     end
 
     shared_examples 'it submits feedback to Akismet' do
-      it 'queus a job tu submit feedback' do
+      it 'queues a job to submit feedback' do
         expect {
           reviewable.perform admin, action
         }.to change(Jobs::UpdateAkismetStatus.jobs, :size).by(1)

--- a/spec/models/reviewable_akismet_user_spec.rb
+++ b/spec/models/reviewable_akismet_user_spec.rb
@@ -53,6 +53,8 @@ describe 'ReviewableAkismetUser', if: defined?(Reviewable) do
     let(:user) { Fabricate(:user) }
     let(:reviewable) { ReviewableAkismetUser.needs_review!(target: user, created_by: admin) }
 
+    before { UserAuthToken.generate!(user_id: user.id) }
+
     shared_examples 'it logs actions in the staff actions logger' do
       it 'creates a UserHistory that reflects the action taken' do
         reviewable.perform admin, action
@@ -77,23 +79,26 @@ describe 'ReviewableAkismetUser', if: defined?(Reviewable) do
       end
     end
 
+    shared_examples 'it submits feedback to Akismet' do
+      it 'queus a job tu submit feedback' do
+        expect {
+          reviewable.perform admin, action
+        }.to change(Jobs::UpdateAkismetStatus.jobs, :size).by(1)
+      end
+    end
+
     describe '#perform_not_spam' do
       let(:action) { :not_spam }
       let(:action_name) { 'confirmed_ham' }
       let(:flag_stat_status) { :disagreed }
 
       it_behaves_like 'it logs actions in the staff actions logger'
+      it_behaves_like 'it submits feedback to Akismet'
 
       it 'sets post as clear and reviewable status is changed to rejected' do
         result = reviewable.perform admin, action
 
         expect(result.transition_to).to eq :rejected
-      end
-
-      it 'sends feedback to Akismet since post was not spam' do
-        expect {
-          reviewable.perform admin, action
-        }.to change(Jobs::UpdateAkismetStatus.jobs, :size).by(1)
       end
     end
 
@@ -103,6 +108,7 @@ describe 'ReviewableAkismetUser', if: defined?(Reviewable) do
       let(:flag_stat_status) { :agreed }
 
       it_behaves_like 'it logs actions in the staff actions logger'
+      it_behaves_like 'it submits feedback to Akismet'
 
       it 'confirms spam and reviewable status is changed to deleted' do
         result = reviewable.perform admin, action


### PR DESCRIPTION
Looks like I overlooked some details when developing how the feedback is submitted to Akismet:

- Send feedback always a `ReviewableAkismetPost` is reviewed (except when ignoring).
- By the time the `ReviewableAkismetUser` feedback submission happens, the user could have been already destroyed. Avoid that scenario passing the feedback directly to the job before deleting.