### PR TITLE
FIX: Clean up posts and reviewables when deleteing an Akismet flagged user.

### DIFF
--- a/jobs/regular/confirm_akismet_flagged_posts.rb
+++ b/jobs/regular/confirm_akismet_flagged_posts.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Jobs
+  class ConfirmAkismetFlaggedPosts < Jobs::Base
+    def execute(args)
+      raise Discourse::InvalidParameters.new(:user_id) unless args[:user_id]
+      raise Discourse::InvalidParameters.new(:performed_by_id) unless args[:performed_by_id]
+
+      performed_by = User.find_by(id: args[:performed_by_id])
+      post_ids = Post.with_deleted.where(user_id: args[:user_id]).pluck(:id)
+
+      ReviewableAkismetPost.where(target_id: post_ids).find_each do |reviewable|
+        reviewable.perform(performed_by, :confirm_spam)
+      end
+    end
+  end
+end

--- a/jobs/regular/confirm_akismet_flagged_posts.rb
+++ b/jobs/regular/confirm_akismet_flagged_posts.rb
@@ -9,7 +9,7 @@ module Jobs
       performed_by = User.find_by(id: args[:performed_by_id])
       post_ids = Post.with_deleted.where(user_id: args[:user_id]).pluck(:id)
 
-      ReviewableAkismetPost.where(target_id: post_ids).find_each do |reviewable|
+      ReviewableAkismetPost.where(target_id: post_ids, status: Reviewable.statuses[:pending]).find_each do |reviewable|
         reviewable.perform(performed_by, :confirm_spam)
       end
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -29,10 +29,15 @@ else
 end
 
 after_initialize do
-  require_dependency File.expand_path('../jobs/check_for_spam_posts.rb', __FILE__)
-  require_dependency File.expand_path('../jobs/regular/check_users_for_spam.rb', __FILE__)
-  require_dependency File.expand_path('../jobs/check_akismet_post.rb', __FILE__)
-  require_dependency File.expand_path('../jobs/update_akismet_status.rb', __FILE__)
+  %W[
+    check_for_spam_posts
+    regular/check_users_for_spam
+    regular/confirm_akismet_flagged_posts
+    check_akismet_post
+    update_akismet_status
+  ].each do |filename|
+    require_dependency File.expand_path("../jobs/#{filename}.rb", __FILE__)
+  end
 
   # We want to include this even if the plugin is not enabled, that's why we use false here.
   add_to_serializer(:site, :reviewable_api_enabled, false) { reviewable_api_enabled }

--- a/spec/jobs/regular/confirm_akismet_flagged_posts_spec.rb
+++ b/spec/jobs/regular/confirm_akismet_flagged_posts_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe Jobs::ConfirmAkismetFlaggedPosts do
 
       expect(updated_post_reviewable.status).to eq(Reviewable.statuses[:approved])
     end
+
+    it 'only approves pending flagged posts' do
+      @user_post_reviewable.perform(admin, :confirm_spam)
+      last_update = @user_post_reviewable.updated_at
+      subject.execute(user_id: user.id, performed_by_id: admin.id)
+
+      updated_post_reviewable = @user_post_reviewable.reload
+
+      expect(updated_post_reviewable.updated_at).to eq(last_update)
+    end
   end
 
   def reviewable_post_for(user)

--- a/spec/jobs/regular/confirm_akismet_flagged_posts_spec.rb
+++ b/spec/jobs/regular/confirm_akismet_flagged_posts_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Jobs::ConfirmAkismetFlaggedPosts do
+  describe '#execute' do
+    let(:user) { Fabricate(:user) }
+
+    it 'raises an exception if :user_id is not provided' do
+      expect do
+        subject.execute({})
+      end.to raise_error(Discourse::InvalidParameters)
+    end
+
+    it 'raises an exception if :performed_by_id is not provided' do
+      expect do
+        subject.execute(user_id: user.id)
+      end.to raise_error(Discourse::InvalidParameters)
+    end
+
+    let(:admin) { Fabricate(:admin) }
+
+    before do
+      @user_post_reviewable = reviewable_post_for(user)
+    end
+
+    it 'approves every flagged post' do
+      subject.execute(user_id: user.id, performed_by_id: admin.id)
+
+      updated_post_reviewable = @user_post_reviewable.reload
+
+      expect(updated_post_reviewable.status).to eq(Reviewable.statuses[:approved])
+    end
+
+    it 'approves every flagged post even if the post was already deleted' do
+      @user_post_reviewable.target.trash!
+      subject.execute(user_id: user.id, performed_by_id: admin.id)
+
+      updated_post_reviewable = @user_post_reviewable.reload
+
+      expect(updated_post_reviewable.status).to eq(Reviewable.statuses[:approved])
+    end
+  end
+
+  def reviewable_post_for(user)
+    post = Fabricate(:post, user: user)
+    ReviewableAkismetPost.needs_review!(target: post, created_by: admin)
+  end
+end


### PR DESCRIPTION
When performing a delete action on a `ReviewableAkismetUser`, we must:
  - Delete all of their posts.
  - Approve `ReviewableAkismetPost`s associated to the user.
  - Approve existing `ReviewableFlaggedPost`s associated to the user.

Relevant discussion: https://meta.discourse.org/t/discourse-akismet-anti-spam/109337/4?u=roman_rizzi