### PR TITLE
[WIP] FIX: Use top-level namespace for base classes

### DIFF
--- a/jobs/check_akismet_post.rb
+++ b/jobs/check_akismet_post.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class CheckAkismetPost < Jobs::Base
+  class CheckAkismetPost < ::Jobs::Base
 
     # Check a single post for spam. We do this for TL0 to get a faster response
     # without batching.

--- a/jobs/regular/check_users_for_spam.rb
+++ b/jobs/regular/check_users_for_spam.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class CheckUsersForSpam < Jobs::Base
+  class CheckUsersForSpam < ::Jobs::Base
     def execute(args)
       user = User.includes(:user_profile).find_by(id: args[:user_id])
       raise Discourse::InvalidParameters.new(:user_id) unless user.present?

--- a/jobs/regular/confirm_akismet_flagged_posts.rb
+++ b/jobs/regular/confirm_akismet_flagged_posts.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class ConfirmAkismetFlaggedPosts < Jobs::Base
+  class ConfirmAkismetFlaggedPosts < ::Jobs::Base
     def execute(args)
       raise Discourse::InvalidParameters.new(:user_id) unless args[:user_id]
       raise Discourse::InvalidParameters.new(:performed_by_id) unless args[:performed_by_id]

--- a/jobs/update_akismet_status.rb
+++ b/jobs/update_akismet_status.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class UpdateAkismetStatus < Jobs::Base
+  class UpdateAkismetStatus < ::Jobs::Base
     def execute(args)
       return unless SiteSetting.akismet_enabled?
 


### PR DESCRIPTION
Zeitwerk is failing when we are searching for Jobs::Onceoff and Jobs::Base without going back to the top-level namespace (this is correlated to the fact that we got Onceoff base class and module with the same name). 

I noticed that in plugins we are using sometimes :: and sometimes not and that gives me comfort that this change will not break anything.

Travis error: https://travis-ci.org/discourse/discourse/jobs/585072364