### PR TITLE
FEATURE: Track akismet state for users

### DIFF
--- a/assets/javascripts/discourse-akismet/connectors/admin-users-list-icon/akismet-icon.hbs
+++ b/assets/javascripts/discourse-akismet/connectors/admin-users-list-icon/akismet-icon.hbs
@@ -1,0 +1,9 @@
+{{#if new}}
+  {{d-icon "far-clock" title=(concat "admin.akismet_states." user.akismet_state)}}
+{{else if skipped}}
+  {{d-icon "eye-slash" title=(concat "admin.akismet_states." user.akismet_state)}}
+{{else if checked}}
+  {{d-icon "check" title=(concat "admin.akismet_states." user.akismet_state)}}
+{{else if spam}}
+  {{d-icon "times" title=(concat "admin.akismet_states." user.akismet_state)}}
+{{/if}}

--- a/assets/javascripts/discourse-akismet/connectors/admin-users-list-icon/akismet-icon.hbs
+++ b/assets/javascripts/discourse-akismet/connectors/admin-users-list-icon/akismet-icon.hbs
@@ -1,7 +1,7 @@
 {{#if new}}
   {{d-icon "far-clock" title=(concat "admin.akismet_states." user.akismet_state)}}
 {{else if skipped}}
-  {{d-icon "eye-slash" title=(concat "admin.akismet_states." user.akismet_state)}}
+  {{d-icon "question" title=(concat "admin.akismet_states." user.akismet_state)}}
 {{else if checked}}
   {{d-icon "check" title=(concat "admin.akismet_states." user.akismet_state)}}
 {{else if spam}}

--- a/assets/javascripts/discourse-akismet/connectors/admin-users-list-icon/akismet-icon.js.es6
+++ b/assets/javascripts/discourse-akismet/connectors/admin-users-list-icon/akismet-icon.js.es6
@@ -1,0 +1,9 @@
+export default {
+  setupComponent(args, component) {
+    const state = args.user.akismet_state;
+    component.set("new", state === "new");
+    component.set("skipped", state === "skipped");
+    component.set("checked", state === "checked");
+    component.set("spam", state === "spam");
+  }
+};

--- a/assets/stylesheets/akismet-icon.scss
+++ b/assets/stylesheets/akismet-icon.scss
@@ -1,0 +1,3 @@
+.akismet-icon {
+  display: inline-block;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -9,6 +9,11 @@ en:
             confirmed_spam_deleted: "Confirm spam and delete user"
             dismissed: 'Dismiss spam'
             ignored: 'Ignore spam'
+      akismet_states:
+        new: Akismet hasn't check this user for spam yet.
+        skipped: This user doesn't have enough information to be reviewed by Akismet.
+        checked: Akismet checked this user and decided that it's not spam.
+        spam: Akismet decided that this user is spam.
             
     akismet:
       title: "Akismet"

--- a/db/migrate/20191031193436_remove_old_akismet_states.rb
+++ b/db/migrate/20191031193436_remove_old_akismet_states.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RemoveOldAkismetStates < ActiveRecord::Migration[6.0]
+  def up
+    DB.exec(<<~SQL, updated_at: 5.minutes.ago
+      DELETE FROM post_custom_fields
+      WHERE name = 'AKISMET_STATE' AND value = 'needs_review' AND updated_at < :updated_at
+    SQL
+    )
+  end
+
+  def down
+  end
+end

--- a/lib/discourse_akismet/users_bouncer.rb
+++ b/lib/discourse_akismet/users_bouncer.rb
@@ -10,12 +10,11 @@ module DiscourseAkismet
         !Reviewable.exists?(target: user)
     end
 
-    def enqueue_for_check(user)
-      return unless should_check?(user)
+    private
+
+    def enqueue_job(user)
       Jobs.enqueue(:check_users_for_spam, user_id: user.id)
     end
-
-    private
 
     def before_check(user)
       should_check?(user)
@@ -29,9 +28,12 @@ module DiscourseAkismet
       )
 
       add_score(reviewable, 'akismet_spam_user')
+      move_to_state(user, 'spam')
     end
 
-    def mark_as_clear(user); end
+    def mark_as_clear(user)
+      move_to_state(user, 'checked')
+    end
 
     def args_for(user)
       profile = user.user_profile

--- a/plugin.rb
+++ b/plugin.rb
@@ -14,6 +14,7 @@ load File.expand_path('../lib/discourse_akismet/users_bouncer.rb', __FILE__)
 load File.expand_path('../lib/discourse_akismet/posts_bouncer.rb', __FILE__)
 load File.expand_path('../lib/akismet.rb', __FILE__)
 register_asset "stylesheets/reviewable-akismet-post-styles.scss"
+register_asset "stylesheets/akismet-icon.scss"
 
 after_initialize do
   %W[
@@ -39,7 +40,7 @@ after_initialize do
   end
 
   add_to_serializer(:admin_user_list, :akismet_state) do
-    object.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] || 'new'
+    object.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]
   end
 
   # Store extra data for akismet

--- a/plugin.rb
+++ b/plugin.rb
@@ -38,6 +38,10 @@ after_initialize do
     end
   end
 
+  add_to_serializer(:admin_user_list, :akismet_state) do
+    object.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] || 'new'
+  end
+
   # Store extra data for akismet
   on(:post_created) do |post, params|
     bouncer = DiscourseAkismet::PostsBouncer.new
@@ -47,13 +51,6 @@ after_initialize do
 
       # Enqueue checks for TL0 posts faster
       bouncer.enqueue_for_check(post) if post.user.trust_level == 0
-    end
-  end
-
-  # When staff agrees a flagged post is spam, send it to akismet
-  on(:confirmed_spam_post) do |post|
-    if SiteSetting.akismet_enabled?
-      Jobs.enqueue(:update_akismet_status, post_id: post.id, status: 'spam')
     end
   end
 


### PR DESCRIPTION
This depends on #46.

Checked users:
<img width="540" alt="Screen Shot 2019-10-31 at 15 28 53" src="https://user-images.githubusercontent.com/5025816/67977522-091e8600-fbf7-11e9-850a-0ec5a5b9e6b8.png">

Spam users:
<img width="405" alt="Screen Shot 2019-10-31 at 15 29 54" src="https://user-images.githubusercontent.com/5025816/67977547-12a7ee00-fbf7-11e9-8e08-ad158c5bdaf3.png">

Skipped users:
<img width="587" alt="Screen Shot 2019-10-31 at 15 33 26" src="https://user-images.githubusercontent.com/5025816/67977572-1f2c4680-fbf7-11e9-815a-0225619ca297.png">

Unprocessed users:
<img width="467" alt="Screen Shot 2019-10-31 at 15 49 43" src="https://user-images.githubusercontent.com/5025816/67977598-2bb09f00-fbf7-11e9-8b8e-6176a4fffcc2.png">



