### PR TITLE
DEV: Don't raise an exception inside a job

### DIFF
--- a/jobs/regular/check_akismet_post.rb
+++ b/jobs/regular/check_akismet_post.rb
@@ -8,8 +8,7 @@ module Jobs
     def execute(args)
       return unless SiteSetting.akismet_enabled?
 
-      post = Post.find_by(id: args[:post_id], user_deleted: false)
-      return if post.blank?
+      return unless post = Post.find_by(id: args[:post_id], user_deleted: false)
 
       return if ReviewableQueuedPost.exists?(target: post)
 

--- a/jobs/regular/check_akismet_post.rb
+++ b/jobs/regular/check_akismet_post.rb
@@ -9,7 +9,7 @@ module Jobs
       return unless SiteSetting.akismet_enabled?
 
       post = Post.find_by(id: args[:post_id], user_deleted: false)
-      raise Discourse::InvalidParameters.new(:post_id) if post.nil?
+      return if post.blank?
 
       return if ReviewableQueuedPost.exists?(target: post)
 


### PR DESCRIPTION
Raising an exception inside a job creates noise in the logs each time we raise an exception. A return should be enough to abort the job execution.