### PR TITLE
FEATURE: add post link in Akismet notification message

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -22,7 +22,7 @@ en:
       text_body_template: |
         Hello,
 
-        Our automated spam filter, [Akismet](https://akismet.com/), has temporarily hidden your post in *%{topic_title}* for review.
+        Our automated spam filter, [Akismet](https://akismet.com/), has temporarily hidden [your post](%{post_link}) in *%{topic_title}* for review.
 
         A [staff member](%{base_url}/about) will review your post soon, and it should appear shortly.
 

--- a/lib/discourse_akismet/posts_bouncer.rb
+++ b/lib/discourse_akismet/posts_bouncer.rb
@@ -113,7 +113,7 @@ module DiscourseAkismet
     end
 
     def notify_poster(post)
-      SystemMessage.new(post.user).create('akismet_spam', topic_title: post.topic.title)
+      SystemMessage.new(post.user).create('akismet_spam', topic_title: post.topic.title, post_link: post.full_url)
     end
 
     def comment_content(post)

--- a/spec/lib/posts_bouncer_spec.rb
+++ b/spec/lib/posts_bouncer_spec.rb
@@ -101,6 +101,10 @@ describe DiscourseAkismet::PostsBouncer do
       expect(reviewable_akismet_post.post).to eq post
       expect(reviewable_akismet_post.reviewable_by_moderator).to eq true
       expect(reviewable_akismet_post.payload['post_cooked']).to eq post.cooked
+
+      # notifies user that post is hidden and includes post URL
+      expect(Post.last.raw).to include(post.full_url)
+      expect(Post.last.raw).to include(post.topic.title)
     end
 
     it 'Creates a new score for the new reviewable' do


### PR DESCRIPTION
https://meta.discourse.org/t/improvement-to-akismet-has-temporarily-hidden-your-post-email/142279/3?u=techapj