### PR TITLE
FIX: Correctly send feedback to Akismet when the first post of a topic is flagged

### DIFF
--- a/lib/discourse_akismet/bouncer.rb
+++ b/lib/discourse_akismet/bouncer.rb
@@ -7,7 +7,6 @@ module DiscourseAkismet
     AKISMET_STATE = 'AKISMET_STATE'
 
     def submit_feedback(target, status)
-      return unless suspect?(target)
       raise Discourse::InvalidParameters.new(:status) unless VALID_STATUSES.include?(status)
       feedback = args_for(target)
 

--- a/lib/discourse_akismet/posts_bouncer.rb
+++ b/lib/discourse_akismet/posts_bouncer.rb
@@ -68,7 +68,7 @@ module DiscourseAkismet
     def args_for(post)
       extra_args = {
         blog: Discourse.base_url,
-        content_type: 'forum-post',
+        content_type: post.is_first_post? ? 'forum-post' : 'reply',
         referrer: post.custom_fields['AKISMET_REFERRER'],
         permalink: "#{Discourse.base_url}#{post.url}",
         comment_author: post.user.try(:username),
@@ -126,7 +126,10 @@ module DiscourseAkismet
     end
 
     def comment_content(post)
-      post.is_first_post? ? "#{post.topic && post.topic.title}\n\n#{post.raw}" : post.raw
+      return post.raw unless post.is_first_post?
+
+      topic = post.topic || Topic.with_deleted.find_by(id: post.topic_id)
+      "#{topic && topic.title}\n\n#{post.raw}"
     end
   end
 end

--- a/lib/discourse_akismet/users_bouncer.rb
+++ b/lib/discourse_akismet/users_bouncer.rb
@@ -11,12 +11,9 @@ module DiscourseAkismet
         .where("ucf.value = 'new' OR (ucf.value = 'skipped' AND users.created_at > ?)", 1.day.ago)
     end
 
-    def should_check?(user)
-      SiteSetting.akismet_review_users? && super(user)
-    end
-
     def suspect?(user)
-      user.trust_level === TrustLevel[0] &&
+      SiteSetting.akismet_review_users? &&
+        user.trust_level === TrustLevel[0] &&
         user.user_profile.bio_raw.present? &&
         user.user_auth_token_logs&.last&.client_ip.present?
     end
@@ -30,10 +27,10 @@ module DiscourseAkismet
         content_type: 'signup',
         permalink: "#{Discourse.base_url}/u/#{user.username_lower}",
         comment_author: user.username,
-        comment_content: profile.bio_raw,
-        comment_author_url: profile.website,
-        user_ip: token.client_ip.to_s,
-        user_agent: token.user_agent
+        comment_content: profile&.bio_raw,
+        comment_author_url: profile&.website,
+        user_ip: token&.client_ip&.to_s,
+        user_agent: token&.user_agent
       }
 
       # Sending the email to akismet is optional

--- a/spec/fabricators/reviewable_akismet_post_fabricator.rb
+++ b/spec/fabricators/reviewable_akismet_post_fabricator.rb
@@ -14,5 +14,10 @@ Fabricator(:reviewable_akismet_user) do
   type 'ReviewableAkismetUser'
   created_by { Discourse.system_user }
   target_type 'User'
-  target { Fabricate(:user) }
+  target do
+    Fabricate(:user, trust_level: TrustLevel[0]).tap do |user|
+      user.user_profile.bio_raw = "I am batman"
+      user.user_auth_token_logs = [UserAuthTokenLog.new(client_ip: '127.0.0.1', action: 'an_action')]
+    end
+  end
 end

--- a/spec/models/reviewable_akismet_post_spec.rb
+++ b/spec/models/reviewable_akismet_post_spec.rb
@@ -72,7 +72,7 @@ describe 'ReviewableAkismetPost' do
     let(:reviewable) { ReviewableAkismetPost.needs_review!(target: post, created_by: admin).reload }
 
     before do
-      post.trash!(admin)
+      PostDestroyer.new(admin, post).destroy
     end
 
     shared_examples 'It logs actions in the staff actions logger' do


### PR DESCRIPTION
I introduced this bug a couple of months ago. Our specs didn't catch it because I used `post.trash!` instead of using the post destroyer, which is what `PostsBouncer` does.

The plugin didn't send the feedback to Akismet if the first post of the topic was flagged. The `suspect?` check was causing problems and is not necessary since we're sure that the target was previously flagged. Additionally, we'll send the `reply` content-type if the post is not the first one.

> forum-post: A top-level forum post.
> reply: A reply to a top-level forum post.

I added some more tests to prevent future regressions.