### PR TITLE
DEV: Remove old Akismet custom fields. We don't need to keep them forever

### DIFF
--- a/jobs/scheduled/clean_old_akismet_custom_fields.rb
+++ b/jobs/scheduled/clean_old_akismet_custom_fields.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Jobs
+  class CleanOldAkismetCustomFields < ::Jobs::Scheduled
+    every 1.day
+
+    def execute(args)
+      return unless SiteSetting.akismet_enabled?
+
+      DiscourseAkismet::PostsBouncer.new.clean_old_akismet_custom_fields
+    end
+  end
+end

--- a/lib/discourse_akismet/posts_bouncer.rb
+++ b/lib/discourse_akismet/posts_bouncer.rb
@@ -2,6 +2,12 @@
 
 module DiscourseAkismet
   class PostsBouncer < Bouncer
+    CUSTOM_FIELDS = %w[
+      AKISMET_STATE
+      AKISMET_IP_ADDRESS
+      AKISMET_USER_AGENT
+      AKISMET_REFERRER
+    ]
 
     @@munger = nil
 
@@ -55,6 +61,13 @@ module DiscourseAkismet
       values['AKISMET_REFERRER'] = opts[:referrer] if opts[:referrer].present?
 
       post.upsert_custom_fields(values)
+    end
+
+    def clean_old_akismet_custom_fields
+      PostCustomField
+        .where(name: CUSTOM_FIELDS)
+        .where('created_at <= ?', 2.months.ago)
+        .delete_all
     end
 
     def self.munge_args(&block)

--- a/plugin.rb
+++ b/plugin.rb
@@ -20,6 +20,7 @@ after_initialize do
   %W[
     jobs/scheduled/check_for_spam_posts
     jobs/scheduled/check_for_spam_users
+    jobs/scheduled/clean_old_akismet_custom_fields
     jobs/regular/check_users_for_spam
     jobs/regular/confirm_akismet_flagged_posts
     jobs/regular/check_akismet_post

--- a/spec/jobs/scheduled/clean_old_akismet_custom_fields_spec.rb
+++ b/spec/jobs/scheduled/clean_old_akismet_custom_fields_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Jobs::CleanOldAkismetCustomFields do
+  it 'works' do
+    SiteSetting.akismet_enabled = true
+
+    post = Fabricate(:post)
+    PostCustomField.create!(
+      name: 'AKISMET_IP_ADDRESS', value: '1.2.3',
+      post: post, created_at: 3.months.ago
+    )
+
+    subject.execute({})
+
+    expect(post.reload.custom_fields).to be_empty
+  end
+end

--- a/spec/lib/posts_bouncer_spec.rb
+++ b/spec/lib/posts_bouncer_spec.rb
@@ -85,6 +85,29 @@ describe DiscourseAkismet::PostsBouncer do
       post.reload
       expect(post.custom_fields['AKISMET_IP_ADDRESS']).to eq('0.0.0.0')
     end
+
+    describe '#clean_old_akismet_custom_fields' do
+      before { subject.move_to_state(post, 'skipped') }
+
+      it 'keeps recent Akismet custom fields' do
+        subject.clean_old_akismet_custom_fields
+
+        post.reload
+
+        expect(post.custom_fields.keys).to contain_exactly(*described_class::CUSTOM_FIELDS)
+      end
+
+      it 'removes old Akismet custom fields' do
+        PostCustomField
+          .where(name: described_class::CUSTOM_FIELDS, post: post)
+          .update_all(created_at: 3.months.ago)
+
+        subject.clean_old_akismet_custom_fields
+
+        post.reload
+        expect(post.custom_fields.keys).to be_empty
+      end
+    end
   end
 
   describe '#check_post' do


### PR DESCRIPTION
Keep them for two months just in case we need them to debug something.