### PR TITLE
FEATURE: Staff can suspend users when reviewing Akismet flagged posts

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -21,6 +21,7 @@ en:
       confirm_spam: "Confirm Spam"
       not_spam: "Not Spam"
       confirm_delete: "Confirm Spam & Delete User"
+      confirm_suspend: "Confirm Spam & Suspend User"
       reject_spam_user_delete: "Delete User"
       dismiss: "Dismiss"
       ignore: "Ignore"


### PR DESCRIPTION
The `Confirm Spam & Delete User` button was moved inside the Agree bundle. I also changed the icons to match flagged posts.

![Screen Shot 2020-09-02 at 14 30 23](https://user-images.githubusercontent.com/5025816/92019102-74137e80-ed2c-11ea-947d-14e6ef0cc607.png)
