### PR TITLE
FIX: We don't want to double-process flagged posts.

### DIFF
--- a/jobs/regular/check_akismet_post.rb
+++ b/jobs/regular/check_akismet_post.rb
@@ -10,7 +10,7 @@ module Jobs
 
       return unless post = Post.find_by(id: args[:post_id], user_deleted: false)
 
-      return if ReviewableQueuedPost.exists?(target: post)
+      return if Reviewable.exists?(target: post)
 
       client = Akismet::Client.build_client
       DiscourseAkismet::PostsBouncer.new.perform_check(client, post)

--- a/lib/discourse_akismet/posts_bouncer.rb
+++ b/lib/discourse_akismet/posts_bouncer.rb
@@ -17,7 +17,7 @@ module DiscourseAkismet
         .where('posts.id IS NOT NULL')
         .where('topics.id IS NOT NULL')
         .joins('LEFT OUTER JOIN reviewables ON reviewables.target_id = post_custom_fields.post_id')
-        .where('reviewables.target_type IS NULL OR reviewables.type <> ?', ReviewableQueuedPost.name)
+        .where('reviewables.id IS NULL')
         .includes(post: :topic)
         .references(:post, :topic)
     end

--- a/spec/jobs/regular/check_akismet_post_spec.rb
+++ b/spec/jobs/regular/check_akismet_post_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe Jobs::CheckAkismetPost do
       expect(ReviewableAkismetPost.count).to be_zero
     end
 
+    it 'does not create a reviewable when a reviewable flagged post already exists for that target' do
+      ReviewableFlaggedPost.needs_review!(target: post, created_by: Discourse.system_user)
+
+      subject.execute(post_id: post.id)
+
+      expect(ReviewableAkismetPost.count).to be_zero
+    end
+
     it 'does not create a reviewable when the post is not spam' do
       Akismet::Client.any_instance.stubs(:comment_check).returns(false)
 

--- a/spec/lib/posts_bouncer_spec.rb
+++ b/spec/lib/posts_bouncer_spec.rb
@@ -203,6 +203,13 @@ describe DiscourseAkismet::PostsBouncer do
 
       expect(described_class.to_check).to be_empty
     end
+
+    it 'does not retrieve posts that already had another reviewable flagged post' do
+      subject.move_to_state(post, 'new')
+      ReviewableFlaggedPost.needs_review!(target: post, created_by: Discourse.system_user)
+
+      expect(described_class.to_check).to be_empty
+    end
   end
 
   describe "#should_check?" do


### PR DESCRIPTION
There's a chance a TL3 user flags a TL0 post as spam before Akismet has a chance of processing it. If it happens, only a flagged post approved by the system will appear in the queue. Staff won't be able to restore it from the queue because Akismet already deleted it (should be hidden instead).