### PR TITLE
Mark Akismet posts with a higher score for review

### DIFF
--- a/lib/discourse_akismet/posts_bouncer.rb
+++ b/lib/discourse_akismet/posts_bouncer.rb
@@ -130,7 +130,7 @@ module DiscourseAkismet
         payload: { post_cooked: post.cooked }
       )
 
-      add_score(reviewable, 'akismet_spam_post')
+      add_score(reviewable, 'akismet_spam_post', force_review: true)
       move_to_state(post, 'confirmed_spam')
     end
 

--- a/lib/discourse_akismet/users_bouncer.rb
+++ b/lib/discourse_akismet/users_bouncer.rb
@@ -58,7 +58,7 @@ module DiscourseAkismet
         payload: { username: user.username, name: user.name, email: user.email, bio: user.user_profile.bio_raw }
       )
 
-      add_score(reviewable, 'akismet_spam_user')
+      add_score(reviewable, 'akismet_spam_user', force_review: true)
       move_to_state(user, 'confirmed_spam')
     end
 


### PR DESCRIPTION
For forums that filter low/medium/high priority queue, Akismet's spam filters
may get lost.
Forcing a higher score ensures that these reviewables will appear in the queue.